### PR TITLE
fix(index): don’t show loading state when pull up loading

### DIFF
--- a/pages/index/index.js
+++ b/pages/index/index.js
@@ -42,12 +42,9 @@ Page({
 
   pullUpLoad: function (e) {
     if (this.data.list.length === 0) return;
-    this.setData({
-      loading: false
-    })
     app.fetchApi(api.getShots({page: ++this.index}), (err, res) => {
       //更新数据
-      this.setData({list: this.data.list.concat(res), loading: true})
+      this.setData({list: this.data.list.concat(res)})
     })
   },
 })

--- a/pages/index/index.wxml
+++ b/pages/index/index.wxml
@@ -2,7 +2,7 @@
 <loading hidden="{{loading}}">
   加载中...
 </loading>
-<scroll-view class="container img-content" style="height: {{windowHeight}}px; width: {{windowWidth}}px; " scroll-y="true" bindscrolltoupper="pullDownRefresh" bindscrolltolower="pullUpLoad">
+<scroll-view class="container img-content" style="height: {{windowHeight}}px; width: {{windowWidth}}px; " scroll-y="true" bindscrolltoupper="pullDownRefresh" bindscrolltolower="pullUpLoad" lower-threshold="800">
       <navigator wx:for="{{list}}" wx:for-index="id" class="img-nav" url="../detail/detail?id={{item.id}}">
         <image src="{{item.images.normal}}"  style="margin: 1px 2px;width: {{(windowWidth - 12)/3}}px;" mode="scaleToFill" />
       </navigator>


### PR DESCRIPTION
当距离底部 800px 时就开始刷新
取消下拉刷新时的加载状态 
这样体验比较无缝，不会有割裂的感觉
@nicesu 
